### PR TITLE
Fixed bug on UNet

### DIFF
--- a/scripts/predict_tumor_params.py
+++ b/scripts/predict_tumor_params.py
@@ -85,13 +85,15 @@ def infer_parameters(dataset_name: str, model: str, data_folder: str, output_bas
     dataset = CustomDataset(data_folder, test_keys)
     data_loader = DataLoader(dataset, batch_size=1, shuffle=False)
     os.makedirs(output_base, exist_ok=True)
+    # Obtain the shape of the input
+    shape_data = dataset[0][0].shape # First [0] gets the sample tuple, second [0] extracts the image (data['data']) from it
 
     # Create output directories
     output_folder = os.path.join(output_base, f"_{model}_{signature}")
     os.makedirs(os.path.join(output_folder, "optimizeOutputPatients"), exist_ok=True)
 
     # Initialize InferenceManager and load checkpoint
-    infer_manager = InferenceManager(plan, configuration='3d_fullres', model=model, device=device, dataset_json=dataset_json)
+    infer_manager = InferenceManager(plan, configuration='3d_fullres', model=model, device=device, dataset_json=dataset_json, shape_data=shape_data)
     
     if chkpt and os.path.exists(chkpt):
         checkpoint_path = chkpt

--- a/src/TumorNetSolvers/inference/inference_manager.py
+++ b/src/TumorNetSolvers/inference/inference_manager.py
@@ -22,7 +22,7 @@ class InferenceManager:
     """
 
     def __init__(self, plans: dict, configuration: str, model: Literal['ViT', 'TumorSurrogate', 'nnUnet'] = "ViT",
-                 device: torch.device = torch.device(f'cuda:0'),  dataset_json :str =''):
+                 device: torch.device = torch.device(f'cuda:0'),  dataset_json :str ='', shape_data: torch.Size = None):
         self.device = device
         self.model = model
 
@@ -30,6 +30,7 @@ class InferenceManager:
         self.plans_manager = PlansManager(plans)
         self.configuration_manager = self.plans_manager.get_configuration(configuration)
         self.dataset_json= dataset_json
+        self.shape_data = shape_data
         # Model initialization
         self.network = self._initialize_model()
 
@@ -76,6 +77,7 @@ class InferenceManager:
             arch_kwargs_req_import=arch_init_kwargs_req_import,
             input_channels=num_input_channels,
             output_channels=num_output_channels,
+            inputs_shape=self.shape_data,
             allow_init=True,
             deep_supervision=enable_deep_supervision
         )

--- a/src/TumorNetSolvers/training/updating_trainer.py
+++ b/src/TumorNetSolvers/training/updating_trainer.py
@@ -294,6 +294,7 @@ class Trainer(object):
             arch_kwargs_req_import=arch_init_kwargs_req_import,
             input_channels=num_input_channels,
             output_channels=num_output_channels,
+            inputs_shape=self.shape_data,
             allow_init=True,
             deep_supervision=enable_deep_supervision
         )
@@ -640,9 +641,11 @@ class Trainer(object):
                                                     pin_memory=self.device.type == 'cuda',
                                                     wait_time=0.002)
         # Initialize the data generators
-        _ = next(mt_gen_train)
+        init_mt_gen_train = next(mt_gen_train)
         _ = next(mt_gen_val)
-        return mt_gen_train, mt_gen_val
+        # Obtain the shape of data
+        shape_data = init_mt_gen_train['data'].shape # Both are the same
+        return mt_gen_train, mt_gen_val, shape_data
 
 
     @staticmethod
@@ -700,7 +703,7 @@ class Trainer(object):
     def on_train_start(self):
         # dataloaders must be instantiated here (instead of __init__) because they need access to the training data
         # which may not be present when doing inference
-        self.dataloader_train, self.dataloader_val = self.get_dataloaders()
+        self.dataloader_train, self.dataloader_val, self.shape_data = self.get_dataloaders()
 
         if not self.was_initialized:
             self.initialize()


### PR DESCRIPTION
The definition of the linear layer has to be done in the init instead of the forward function. If done in the forward function, the linear layer is initialized on every forward pass to be different, and the weights are not updated. In other words, the network is only learning to deal with noise. But not using the parameters as an influence on the predictions.

The solution is to shift the linear layer definition to the init and apply the corresponding changes to the forward pass. For being able to obtain the correct shape of the bottleneck for the linear layer, the input shape is used as an argument of the definition of the nnUNet. This is reduced via the strides up to the level of the bottleneck. The shape argument has been modified at all locations required for it to be imported into the nnUNet.

This solution to the bug makes the nnUNet the best network. The paper will be updated to v2 with the updated discussion based on the fixed bug.